### PR TITLE
Prevent Railway from failing the deployment

### DIFF
--- a/server/Procfile
+++ b/server/Procfile
@@ -1,0 +1,1 @@
+web: bundle install; bundle exec rails db:migrate; bundle exec rails server

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,1 +1,0 @@
-web: bundle install; bundle exec rails db:migrate; bundle exec rails server

--- a/server/app/controllers/home_controller.rb
+++ b/server/app/controllers/home_controller.rb
@@ -1,0 +1,5 @@
+class HomeController < ApplicationController
+  def hello
+    render plain: 'Welcome to the On-Air-Device API'
+  end
+end

--- a/server/config/routes.rb
+++ b/server/config/routes.rb
@@ -2,7 +2,8 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Defines the root path route ("/")
-  # root "articles#index"
+  root "home#hello"
+
   namespace :api do
     namespace 'v1' do
       scope 'mqtt' do

--- a/server/lib/tasks/assets.rake
+++ b/server/lib/tasks/assets.rake
@@ -1,0 +1,6 @@
+namespace :assets do
+  desc 'Provide deployment pipeline with a rake task to run that does nothing.'
+  task :precompile do
+    puts 'Not precompiling assets...'
+  end
+end


### PR DESCRIPTION
# Description, Motivation, and Context

This is to update how the deployment platform spins up the deployment.
The deployment is failing as it is trying to run rake assets:precompile in order to compile JS assets for a non-existent frontend for our app (as it is set up as API only, there are no views in this rails server)

# Relevant Links (Stack Overflow, JIRA, RFC, etc)

https://dev.to/bajena/moving-a-hanami-application-from-heroku-to-railway-4d7o
https://stackoverflow.com/questions/74061615/rails-6-api-deployment-error-on-railway-rake-assetsprecompile
