### PR TITLE
Install dotenv so we can use .env

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -30,6 +30,9 @@ gem 'tzinfo-data', platforms: %i[ mingw mswin x64_mingw jruby ]
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 
+# MQTT for Pub/Sub
+gem 'mqtt', git: 'https://github.com/njh/ruby-mqtt.git'
+
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
@@ -39,6 +42,9 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]
+
+  # Load .env variables
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: https://github.com/njh/ruby-mqtt.git
+  revision: 271ee631f128e66732ece935e752f13970d4267b
+  specs:
+    mqtt (0.6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -76,6 +82,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -186,8 +196,10 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  dotenv-rails
   factory_bot_rails
   faker
+  mqtt!
   pg (~> 1.1)
   puma (~> 5.0)
   rails (~> 7.0.3, >= 7.0.3.1)


### PR DESCRIPTION
# Description, Motivation, and Context

Noticed nothing in our `.env` file was loading, so added this gem so we can use `.env` stuff

