### PR TITLE
Install dotenv so we can use .env

### DIFF
--- a/server/Gemfile
+++ b/server/Gemfile
@@ -39,6 +39,7 @@ gem 'bootsnap', require: false
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[ mri mingw x64_mingw ]
+  gem 'dotenv-rails'
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'rspec-rails'

--- a/server/Gemfile.lock
+++ b/server/Gemfile.lock
@@ -76,6 +76,10 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
+    dotenv (2.8.1)
+    dotenv-rails (2.8.1)
+      dotenv (= 2.8.1)
+      railties (>= 3.2)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -186,6 +190,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   debug
+  dotenv-rails
   factory_bot_rails
   faker
   pg (~> 1.1)


### PR DESCRIPTION
# Description, Motivation, and Context

Noticed that nothing in the `.env` files were being pulled in